### PR TITLE
Suggested change to address ZIP-212 issues

### DIFF
--- a/walletrpc/service.proto
+++ b/walletrpc/service.proto
@@ -50,7 +50,7 @@ message LightdInfo {
     bool   taddrSupport = 3;
     string chainName = 4;
     uint64 saplingActivationHeight = 5;
-    string consensusBranchId = 6;   // This should really be u32 or []byte, but string for readability
+    string branchId = 6;   // This should really be u32 or []byte, but string for readability
     uint64 blockHeight = 7;
 }
 


### PR DESCRIPTION
This is a suggestion for reducing the number of users impacted by the "misplaced" funds issue. By updating the current lightwalletd to no longer publish `consensusBranchId`, old wallets can no longer rely on its value (which would be inaccurate for those wallets). Also, it seems this value is no longer used by current zecwallet installations. 

One main tradeoff would be that these users' wallet's would fail to send money out until they upgrade or import their seed elsewhere to regain control of their funds. However, that is likely a better option than "misplacing" funds in such a way that they're tricky to recover. Especially considering that their current wallet cannot successfully send funds. So it is only a perceived rather than actual loss of function.

Additional details here https://github.com/zcash/librustzcash/issues/323
Workaround mentioned here: https://github.com/adityapk00/zecwallet-lite/issues/93

This is not a full fix : it requires additional related changes. This is mainly just intended to convey the concept being discussed.